### PR TITLE
fix: change removeDir deletion method to forceDelete

### DIFF
--- a/src/main/java/ci/RepoSetup.java
+++ b/src/main/java/ci/RepoSetup.java
@@ -41,7 +41,6 @@ public class RepoSetup {
    *
    * @param repoParentDir Path to the parent directory, where we want to store the test repo
    * @throws IOException in case deletion is unsuccessful or dir does not exist
-   * @throws IllegalArgumentException if the file located under the location is not a directory
    */
   public static void removeDir(String repoParentDir) throws IOException {
     File dir = new File(repoParentDir);
@@ -50,7 +49,7 @@ public class RepoSetup {
       throw new IOException("Directoty does not exist at: " + repoParentDir);
     }
 
-    FileUtils.deleteDirectory(dir);
+    FileUtils.forceDelete(dir);
   }
 
   /**

--- a/src/test/java/ci/RepoSetupTest.java
+++ b/src/test/java/ci/RepoSetupTest.java
@@ -39,7 +39,7 @@ class RepoSetupTest {
   @Test
   void removeDirSuccess(@TempDir Path temp) throws Exception {
     /* Contract: removeDir removes a directory if a directory already exists under the given path */
-    Path newFilePath = temp.resolve("newDirectory");
+    Path newFilePath = temp.resolve("newDirectoryTest");
     Files.createDirectory(newFilePath);
     assertDoesNotThrow(() -> RepoSetup.removeDir(newFilePath.toString()));
   }
@@ -49,7 +49,7 @@ class RepoSetupTest {
     /* Contract: removeDir removes a directory if a directory already exists under
      * the given path, in this caseno file exists
      */
-    Path newFilePath = temp.resolve("newDirectory");
+    Path newFilePath = temp.resolve("newDirectoryTest");
     assertThrows(IOException.class, () -> RepoSetup.removeDir(newFilePath.toString()));
   }
 


### PR DESCRIPTION
Was an issue that some empty sub dirs was left after delete, so now forceDelete is used instead to avoid this

close #121